### PR TITLE
Ser etter tilkommet inntekt i alle deler av vilkårsperioden

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektPeriodeTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektPeriodeTjeneste.java
@@ -55,7 +55,7 @@ public class TilkommetInntektPeriodeTjeneste {
 				.combine(opprettTidslinje(input.getForlengelseperioder()), StandardCombinators::leftOnly, input.getForlengelseperioder().isEmpty() ? LocalDateTimeline.JoinStyle.LEFT_JOIN : LocalDateTimeline.JoinStyle.INNER_JOIN);
 
 		if (ytelseGrunnlag.getTilkommetInntektHensyntasFom().isPresent()) {
-			tidlinjeMedTilkommetAktivitet = tidlinjeMedTilkommetAktivitet.combine(new LocalDateSegment<>(new LocalDateInterval(ytelseGrunnlag.getTilkommetInntektHensyntasFom().get(), LocalDateInterval.TIDENES_ENDE), Boolean.TRUE), StandardCombinators::leftOnly, LocalDateTimeline.JoinStyle.INNER_JOIN);
+			tidlinjeMedTilkommetAktivitet = tidlinjeMedTilkommetAktivitet.intersection(new LocalDateInterval(ytelseGrunnlag.getTilkommetInntektHensyntasFom().get(), LocalDateInterval.TIDENES_ENDE));
 		} else if (!tidlinjeMedTilkommetAktivitet.isEmpty()) {
 			throw new IllegalStateException("Hadde ikke startdato for nye regler, men fikk tilkommet inntekt");
 		}

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjeneste.java
@@ -87,7 +87,8 @@ public class TilkommetInntektsforholdTjeneste {
 				.union(dagpengetidslinje, StandardCombinators::union);
 
 		if (!ikkeFiltrerVedFulltFravær) {
-			var utbetalingTidslinje = finnTidslinjeMedFravær((UtbetalingsgradGrunnlag) utbetalingsgradGrunnlag);
+			// Filtrerer bort perioder som ligger utenfor søkte perioder
+			var utbetalingTidslinje = finnTidslinjeForUtbetalingsperiode((UtbetalingsgradGrunnlag) utbetalingsgradGrunnlag);
 			aktivitetTidslinje = aktivitetTidslinje.intersection(utbetalingTidslinje, StandardCombinators::leftOnly);
 		}
 		return aktivitetTidslinje.map(s -> mapTilkommetTidslinje(andelerFraStart, yrkesaktiviteter, utbetalingsgradGrunnlag, s, ikkeFiltrerVedFulltFravær)).compress();
@@ -106,10 +107,9 @@ public class TilkommetInntektsforholdTjeneste {
 				.collect(Collectors.collectingAndThen(Collectors.toList(), s -> new LocalDateTimeline<>(s, StandardCombinators::union)));
 	}
 
-	private static LocalDateTimeline<Boolean> finnTidslinjeMedFravær(UtbetalingsgradGrunnlag utbetalingsgradGrunnlag) {
+	private static LocalDateTimeline<Boolean> finnTidslinjeForUtbetalingsperiode(UtbetalingsgradGrunnlag utbetalingsgradGrunnlag) {
 		return utbetalingsgradGrunnlag.getUtbetalingsgradPrAktivitet().stream()
 				.flatMap(a -> a.getPeriodeMedUtbetalingsgrad().stream())
-				.filter(p -> p.getAktivitetsgrad().map(v -> v.compareTo(Aktivitetsgrad.HUNDRE) < 0).orElse(false))
 				.map(p -> new LocalDateSegment<>(p.getPeriode().getFomDato(), p.getPeriode().getTomDato(), Boolean.TRUE))
 				.collect(Collectors.collectingAndThen(Collectors.toList(), s -> new LocalDateTimeline<>(s, StandardCombinators::alwaysTrueForMatch)));
 	}

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjeneste.java
@@ -110,8 +110,9 @@ public class TilkommetInntektsforholdTjeneste {
 	private static LocalDateTimeline<Boolean> finnTidslinjeForUtbetalingsperiode(UtbetalingsgradGrunnlag utbetalingsgradGrunnlag) {
 		return utbetalingsgradGrunnlag.getUtbetalingsgradPrAktivitet().stream()
 				.flatMap(a -> a.getPeriodeMedUtbetalingsgrad().stream())
-				.map(p -> new LocalDateSegment<>(p.getPeriode().getFomDato(), p.getPeriode().getTomDato(), Boolean.TRUE))
-				.collect(Collectors.collectingAndThen(Collectors.toList(), s -> new LocalDateTimeline<>(s, StandardCombinators::alwaysTrueForMatch)));
+				.map(p -> new LocalDateTimeline<>(p.getPeriode().getFomDato(), p.getPeriode().getTomDato(), true))
+				.reduce(LocalDateTimeline::crossJoin)
+				.orElse(LocalDateTimeline.empty());
 	}
 
 	private static List<LocalDateSegment<Set<StatusOgArbeidsgiver>>> mapTilkommetTidslinje(Collection<BeregningsgrunnlagPrStatusOgAndelDto> andeler,

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
@@ -103,31 +103,7 @@ class AvklaringsbehovUtlederTilkommetInntektTest {
 		assertThat(tilkomneAndeler.size()).isEqualTo(1);
 		assertThat(tilkomneAndeler.iterator().next().arbeidsgiver()).isEqualTo(arbeidsgiver2);
 	}
-
-	@Test
-	void skal_ikke_finne_tilkommet_andel_dersom_det_ikke_er_søkt_utbetalign_for_noen_aktiviteter() {
-
-		var arbeidsgiver = Arbeidsgiver.virksomhet(ARBEIDSGIVER_ORGNR);
-		var arbeidstakerandelFraStart = lagArbeidstakerandel(arbeidsgiver, 1L, AndelKilde.PROSESS_START, InternArbeidsforholdRefDto.nullRef());
-
-		var arbeidsgiver2 = Arbeidsgiver.virksomhet(ARBEIDSGIVER_ORGNR2);
-		var nyAndel = lagArbeidstakerandel(arbeidsgiver2, 2L, AndelKilde.PROSESS_PERIODISERING, InternArbeidsforholdRefDto.nullRef());
-
-		var yrkesaktivitet = lagYrkesaktivitet(arbeidsgiver, STP.minusMonths(10), STP.plusDays(15), InternArbeidsforholdRefDto.nullRef());
-		var nyYrkesaktivitet = lagYrkesaktivitet(arbeidsgiver2, STP.plusDays(1), STP.plusDays(20), InternArbeidsforholdRefDto.nullRef());
-
-		var utbetalingsgradFraStart = new UtbetalingsgradPrAktivitetDto(lagAktivitet(arbeidsgiver, InternArbeidsforholdRefDto.nullRef()), lagUtbetalingsgrader(0, STP.plusDays(2), STP.plusDays(3)));
-		var utbetalingsgradNyAndel = new UtbetalingsgradPrAktivitetDto(lagAktivitet(arbeidsgiver2, InternArbeidsforholdRefDto.nullRef()),
-				List.of(lagPeriodeMedUtbetalingsgrad(50, STP.plusDays(1), STP.plusDays(1)),
-						lagPeriodeMedUtbetalingsgrad(50, STP.plusDays(4), STP.plusDays(20))));
-
-		var periode = Intervall.fraOgMedTilOgMed(STP.plusDays(2), STP.plusDays(3));
-
-		var tilkommetAktivitet = finnTilkomneAndeler(periode, List.of(yrkesaktivitet, nyYrkesaktivitet), List.of(arbeidstakerandelFraStart, nyAndel), new PleiepengerSyktBarnGrunnlag(List.of(utbetalingsgradFraStart, utbetalingsgradNyAndel)), STP);
-
-		assertThat(tilkommetAktivitet.size()).isEqualTo(0);
-	}
-
+	
 	@Test
 	void skal_finne_tilkommet_andel_dersom_en_andel_fra_start_med_overlapp_til_nytt_arbeid() {
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
@@ -103,7 +103,7 @@ class AvklaringsbehovUtlederTilkommetInntektTest {
 		assertThat(tilkomneAndeler.size()).isEqualTo(1);
 		assertThat(tilkomneAndeler.iterator().next().arbeidsgiver()).isEqualTo(arbeidsgiver2);
 	}
-	
+
 	@Test
 	void skal_finne_tilkommet_andel_dersom_en_andel_fra_start_med_overlapp_til_nytt_arbeid() {
 


### PR DESCRIPTION
Før kjørte logikk for ny inntekt etter at vi var ferdig med uttak, og då ga det meining å sjekke kun perioder der man faktisk hadde utbetalingsgrad > 0 (Aktivitetsgrad < 100). No lager vi uttaksplanen etter at vi har vurdert ny inntekt, og vi må derfor sjå på alle periodene