### PR TITLE
Ser ikkje på permisjoner ved utledning av ny inntekt

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjeneste.java
@@ -21,7 +21,6 @@ import no.nav.folketrygdloven.kalkulator.modell.iay.AktørArbeidDto;
 import no.nav.folketrygdloven.kalkulator.modell.iay.InntektArbeidYtelseGrunnlagDto;
 import no.nav.folketrygdloven.kalkulator.modell.iay.YrkesaktivitetDto;
 import no.nav.folketrygdloven.kalkulator.modell.iay.YtelseAnvistDto;
-import no.nav.folketrygdloven.kalkulator.modell.iay.permisjon.PermisjonPerYrkesaktivitet;
 import no.nav.folketrygdloven.kalkulator.modell.svp.PeriodeMedUtbetalingsgradDto;
 import no.nav.folketrygdloven.kalkulator.modell.typer.Aktivitetsgrad;
 import no.nav.folketrygdloven.kalkulator.modell.typer.Arbeidsgiver;
@@ -156,8 +155,7 @@ public class TilkommetInntektsforholdTjeneste {
 				.filter(ya -> !mapTilAktivitetStatus(ya).equals(AktivitetStatus.UDEFINERT))
 				.flatMap(ya -> {
 							var ansettelsesTidslinje = finnAnsettelseTidslinje(ya);
-							var permisjonTidslinje = PermisjonPerYrkesaktivitet.utledPermisjonPerYrkesaktivitet(ya, Collections.emptyMap(), skjæringstidspunkt);
-							return ansettelsesTidslinje.disjoint(permisjonTidslinje)
+							return ansettelsesTidslinje
 									.toSegments().stream()
 									.map(LocalDateSegment::getLocalDateInterval)
 									.filter(p -> p.getTomDato().isAfter(BeregningstidspunktTjeneste.finnBeregningstidspunkt(skjæringstidspunkt)))

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
@@ -129,6 +129,7 @@ class AvklaringsbehovUtlederTilkommetInntektTest {
 
 	@Test
 	void skal_ikke_finne_tilkommet_andel_dersom_en_andel_fra_start_og_med_overlapp_til_nytt_arbeid_med_permisjon() {
+		// Permisjon tas ikke lenger hensyn til ved utledning av tilkommet
 
 		var arbeidsgiver = Arbeidsgiver.virksomhet(ARBEIDSGIVER_ORGNR);
 		var arbeidstakerandelFraStart = lagArbeidstakerandel(arbeidsgiver, 1L, AndelKilde.PROSESS_START, InternArbeidsforholdRefDto.nullRef());
@@ -151,7 +152,8 @@ class AvklaringsbehovUtlederTilkommetInntektTest {
 
 		var tilkommetAktivitet = finnTilkomneAndeler(periode, List.of(yrkesaktivitet, nyYrkesaktivitet), List.of(arbeidstakerandelFraStart, nyAndel), new PleiepengerSyktBarnGrunnlag(List.of(utbetalingsgradFraStart, utbetalingsgradNyAndel)), STP);
 
-		assertThat(tilkommetAktivitet.isEmpty()).isTrue();
+		assertThat(tilkommetAktivitet.size()).isEqualTo(1);
+		assertThat(tilkommetAktivitet.iterator().next().arbeidsgiver()).isEqualTo(arbeidsgiver2);
 	}
 
 	@Test


### PR DESCRIPTION
Siden vi uansett ber bruker om arbeidstid for desse kan vi liksågodt opprette aksjonspunkt dersom bruker har oppgitt å ha jobbet i perioden.