### PR TITLE
Finner inntektgradering kun for perioder der vi har vurdert ny inntekt

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/FinnUttaksgradInntektsgradering.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/FinnUttaksgradInntektsgradering.java
@@ -15,7 +15,10 @@ public class FinnUttaksgradInntektsgradering {
 
     public static LocalDateTimeline<BigDecimal> finn(BeregningsgrunnlagInput input) {
         var beregningsgrunnlagRegel = new MapBeregningsgrunnlagFraVLTilRegel().map(input, input.getBeregningsgrunnlag());
-        beregningsgrunnlagRegel.getBeregningsgrunnlagPerioder().forEach(KalkulusRegler::finnGrenseverdi);
+        beregningsgrunnlagRegel.getBeregningsgrunnlagPerioder()
+		        .stream()
+		        .filter(p -> p.getTilkommetInntektsforholdListe() != null && !p.getTilkommetInntektsforholdListe().isEmpty())
+		        .forEach(KalkulusRegler::finnGrenseverdi);
         return beregningsgrunnlagRegel.getBeregningsgrunnlagPerioder().stream()
                 .filter(p -> p.getTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt() != null)
                 .map(p -> new LocalDateSegment<>(p.getPeriodeFom(), p.getPeriodeTom(), p.getTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt()))


### PR DESCRIPTION
Det er kun i perioder der saksbehandler har vurdert aksjonspunkt for ny inntekt at vi ønsker å finne inntektsgradering. Ellers er det en risiko for at det feiler for perioder på gamle regler fordi disse enda ikke har satt inntekt på alle andeler.