### PR TITLE
FAGSYSTEM-363084: Sjekker inntektsgrunnlag og ikkje brutto pr år for å bestemme om grunnlag er over 6G ved beregning av grenseverdi uten fordeling

### DIFF
--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdi.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdi.java
@@ -1,5 +1,6 @@
 package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
 
+import no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling.RegelFinnGrenseverdiUtenFordeling;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPeriode;
 import no.nav.folketrygdloven.regelmodelloversetter.EksportRegel;
 import no.nav.fpsak.nare.Ruleset;

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/SkalFinneGrenseverdiUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/SkalFinneGrenseverdiUtenFordeling.java
@@ -22,9 +22,15 @@ public class SkalFinneGrenseverdiUtenFordeling extends LeafSpecification<Beregni
 		var ytelsesSpesifiktGrunnlag = grunnlag.getBeregningsgrunnlag().getYtelsesSpesifiktGrunnlag();
 		if (ytelsesSpesifiktGrunnlag instanceof PleiepengerGrunnlagFastsettGrenseverdi pleiepengergrunnlag) {
 			var startdatoNyeGraderingsregler = pleiepengergrunnlag.getStartdatoNyeGraderingsregler();
-			SingleEvaluation resultat = startdatoNyeGraderingsregler == null || grunnlag.getPeriodeFom().isBefore(startdatoNyeGraderingsregler) ? nei() : ja();
+			var skalKjøreMedFordeling = startdatoNyeGraderingsregler == null || grunnlag.getPeriodeFom().isBefore(startdatoNyeGraderingsregler);
+			SingleEvaluation resultat = skalKjøreMedFordeling ? nei() : ja();
 			resultat.setEvaluationProperty("startdatoNyeGraderingsregler", startdatoNyeGraderingsregler);
 			resultat.setEvaluationProperty("periodeFom", grunnlag.getPeriodeFom());
+
+			if (skalKjøreMedFordeling && grunnlag.getTilkommetInntektsforholdListe() != null && !grunnlag.getTilkommetInntektsforholdListe().isEmpty()) {
+				throw new IllegalStateException("Hadde tilkommet inntekt satt i periode for gamle regler");
+			}
+
 			return resultat;
 		} else {
 			return nei();

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/AvkortBGAndelerSomIkkeGjelderArbeidsforholdAndelsmessigUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/AvkortBGAndelerSomIkkeGjelderArbeidsforholdAndelsmessigUtenFordeling.java
@@ -1,4 +1,4 @@
-package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
 
 import java.math.BigDecimal;
 import java.util.Comparator;
@@ -17,7 +17,7 @@ import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
 @RuleDocumentation(AvkortBGAndelerSomIkkeGjelderArbeidsforholdAndelsmessigUtenFordeling.ID)
-public class AvkortBGAndelerSomIkkeGjelderArbeidsforholdAndelsmessigUtenFordeling extends LeafSpecification<BeregningsgrunnlagPeriode> {
+class AvkortBGAndelerSomIkkeGjelderArbeidsforholdAndelsmessigUtenFordeling extends LeafSpecification<BeregningsgrunnlagPeriode> {
     public static final String ID = "FP_BR 29.8.4_uten_fordeling";
     public static final String BESKRIVELSE = "Avkort alle beregningsgrunnlagsandeler som ikke gjelder arbeidsforhold andelsmessig.";
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/AvkortBGAndelerSomIkkeGjelderArbeidsforholdTil0.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/AvkortBGAndelerSomIkkeGjelderArbeidsforholdTil0.java
@@ -1,0 +1,52 @@
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPeriode;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrArbeidsforhold;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrStatus;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+
+@RuleDocumentation(AvkortBGAndelerSomIkkeGjelderArbeidsforholdTil0.ID)
+class AvkortBGAndelerSomIkkeGjelderArbeidsforholdTil0 extends LeafSpecification<BeregningsgrunnlagPeriode> {
+    static final String ID = "FP_BR 29.8.3";
+    static final String BESKRIVELSE = "Avkort alle beregningsgrunnlagsandeler som ikke gjelder arbeidsforhold til 0.";
+
+    AvkortBGAndelerSomIkkeGjelderArbeidsforholdTil0() {
+        super(ID, BESKRIVELSE);
+    }
+
+    @Override
+    public Evaluation evaluate(BeregningsgrunnlagPeriode grunnlag) {
+
+        Map<String, Object> resultater = new HashMap<>();
+        grunnlag.getBeregningsgrunnlagPrStatus().stream()
+            .filter(bgps -> !bgps.erArbeidstakerEllerFrilanser())
+            .forEach(bgps -> {
+                BeregningsgrunnlagPrStatus.builder(bgps)
+                    .medAndelsmessigFørGraderingPrAar(BigDecimal.ZERO)
+                    .build();
+                resultater.put("avkortetPrÅr.status." + bgps.getAktivitetStatus().name(), bgps.getAvkortetPrÅr());
+            });
+
+        BeregningsgrunnlagPrStatus atfl = grunnlag.getBeregningsgrunnlagPrStatus(AktivitetStatus.ATFL);
+        if (atfl != null) {
+            atfl.getFrilansArbeidsforhold().ifPresent(af -> {
+                    BeregningsgrunnlagPrArbeidsforhold.builder(af)
+                        .medAndelsmessigFørGraderingPrAar(BigDecimal.ZERO)
+                        .build();
+                    resultater.put("avkortetPrÅr.status." + atfl.getAktivitetStatus().name() + "." + af.getArbeidsgiverId(), af.getAvkortetPrÅr());
+                });
+        }
+        return beregnet(resultater);
+
+    }
+
+
+
+}

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FastsettAndelForArbeidsforholdUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FastsettAndelForArbeidsforholdUtenFordeling.java
@@ -1,4 +1,4 @@
-package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FastsettAndelForBGAndelerSomGjelderArbeidsforholdUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FastsettAndelForBGAndelerSomGjelderArbeidsforholdUtenFordeling.java
@@ -1,4 +1,4 @@
-package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
 
 import java.math.BigDecimal;
 import java.util.HashMap;

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FastsettAndelLikBruttoBGUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FastsettAndelLikBruttoBGUtenFordeling.java
@@ -1,4 +1,4 @@
-package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
 
 import java.math.BigDecimal;
 
@@ -11,7 +11,7 @@ import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
 @RuleDocumentation(FastsettAndelLikBruttoBGUtenFordeling.ID)
-public class FastsettAndelLikBruttoBGUtenFordeling extends LeafSpecification<BeregningsgrunnlagPeriode> {
+class FastsettAndelLikBruttoBGUtenFordeling extends LeafSpecification<BeregningsgrunnlagPeriode> {
 
     static final String ID = "FP_BR 29.6.2_uten_fordeling";
     static final String BESKRIVELSE = "Fastsett andel lik brutto bg";

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FinnGrenseverdiUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/FinnGrenseverdiUtenFordeling.java
@@ -1,4 +1,4 @@
-package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -17,7 +17,7 @@ import no.nav.fpsak.nare.evaluation.node.SingleEvaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
 @RuleDocumentation(FinnGrenseverdiUtenFordeling.ID)
-public class FinnGrenseverdiUtenFordeling extends LeafSpecification<BeregningsgrunnlagPeriode> {
+class FinnGrenseverdiUtenFordeling extends LeafSpecification<BeregningsgrunnlagPeriode> {
 
 	public static final String ID = "FP_BR 6.2_uten_fordeling";
 	public static final String BESKRIVELSE = "Finn grenseverdi uten fordeling";

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
@@ -1,4 +1,4 @@
-package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
 
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPeriode;
@@ -8,7 +8,7 @@ import no.nav.fpsak.nare.RuleService;
 import no.nav.fpsak.nare.Ruleset;
 import no.nav.fpsak.nare.specification.Specification;
 
-public class RegelFastsettAndelBGOver6GUtenFordeling implements RuleService<BeregningsgrunnlagPeriode> {
+class RegelFastsettAndelBGOver6GUtenFordeling implements RuleService<BeregningsgrunnlagPeriode> {
 	public static final String ID = "FP_BR_29.8_uten_fordeling";
 	public static final String BESKRIVELSE = "Fastsett avkortet BG over 6G når refusjon under 6G";
 	private BeregningsgrunnlagPeriode regelmodell;
@@ -51,7 +51,7 @@ public class RegelFastsettAndelBGOver6GUtenFordeling implements RuleService<Bere
 		}
 
 		//FP_BR_29.8.2 Er totalt BG for beregningsgrunnlagsandeler fra arbeidsforhold > 6G?
-		Specification<BeregningsgrunnlagPeriode> erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel(new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdi(),
+		Specification<BeregningsgrunnlagPeriode> erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel(new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling(),
 				avkortAndelerSomIkkegjelderAFtil0, avkortAndelerAndelsmessigOgFastsettBrukersAndel);
 
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
@@ -1,4 +1,4 @@
-package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi;
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
 
 import no.nav.folketrygdloven.beregningsgrunnlag.fastsette.SjekkBeregningsgrunnlagStørreEnnGrenseverdi;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPeriode;

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling.java
@@ -1,0 +1,38 @@
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
+
+
+import java.math.BigDecimal;
+
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPeriode;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrArbeidsforhold;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrStatus;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.evaluation.node.SingleEvaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+
+@RuleDocumentation(SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling.ID)
+class SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling extends LeafSpecification<BeregningsgrunnlagPeriode> {
+
+    static final String ID = "FP_BR_29.8.2_uten_fordeling";
+    static final String BESKRIVELSE = "Er totalt intektsgrunnlag for andeler fra arbeidsforhold større enn 6G?";
+
+    SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling() {
+        super(ID, BESKRIVELSE);
+    }
+
+    @Override
+    public Evaluation evaluate(BeregningsgrunnlagPeriode grunnlag) {
+        BigDecimal grenseverdi = grunnlag.getGrenseverdi();
+        BeregningsgrunnlagPrStatus atfl = grunnlag.getBeregningsgrunnlagPrStatus(AktivitetStatus.ATFL);
+	    BigDecimal totaltBG = atfl == null ? BigDecimal.ZERO : atfl.getArbeidsforholdIkkeFrilans().stream()
+            .map(BeregningsgrunnlagPrArbeidsforhold::getInntektsgrunnlagInkludertNaturalytelsePrÅr)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        SingleEvaluation resultat = totaltBG.compareTo(grenseverdi) > 0 ? ja() : nei();
+        resultat.setEvaluationProperty("totaltBeregningsgrunnlagFraArbeidsforhold", totaltBG);
+        resultat.setEvaluationProperty("grunnbeløp", grunnlag.getGrunnbeløp());
+        resultat.setEvaluationProperty("grenseverdi", grenseverdi);
+        return resultat;
+    }
+}

--- a/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordelingTest.java
+++ b/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordelingTest.java
@@ -1,0 +1,124 @@
+package no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling;
+
+import static no.nav.folketrygdloven.beregningsgrunnlag.util.DateUtil.TIDENES_ENDE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.Aktivitet;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.Periode;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.Beregningsgrunnlag;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPeriode;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrArbeidsforhold;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrStatus;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Arbeidsforhold;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.evaluation.Resultat;
+
+class SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordelingTest {
+
+	@Test
+	void skal_gi_resultat_JA_for_inntektsgrunnlag_over_grenseverdi() {
+		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
+				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
+				.medBeregningsgrunnlagPrStatus(BeregningsgrunnlagPrStatus
+						.builder()
+						.medAktivitetStatus(AktivitetStatus.ATFL)
+						.medArbeidsforhold(BeregningsgrunnlagPrArbeidsforhold.builder()
+								.medAndelNr(1L)
+								.medBruttoPrÅr(BigDecimal.valueOf(100_000))
+								.medInntektsgrunnlagPrÅr(BigDecimal.valueOf(1_000_000))
+								.medArbeidsforhold(Arbeidsforhold.builder()
+										.medOrgnr("999999999")
+										.medAktivitet(Aktivitet.ARBEIDSTAKERINNTEKT).build()).build())
+						.build()).build();
+
+		Beregningsgrunnlag.builder()
+				.medBeregningsgrunnlagPeriode(periode)
+				.medGrunnbeløp(BigDecimal.valueOf(100_000));
+
+		var evaluate = new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling().evaluate(periode);
+
+		assertThat(evaluate.result()).isEqualTo(Resultat.JA);
+	}
+
+	@Test
+	void skal_gi_resultat_NEI_for_inntektsgrunnlag_under_grenseverdi() {
+		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
+				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
+				.medBeregningsgrunnlagPrStatus(BeregningsgrunnlagPrStatus
+						.builder()
+						.medAktivitetStatus(AktivitetStatus.ATFL)
+						.medArbeidsforhold(BeregningsgrunnlagPrArbeidsforhold.builder()
+								.medAndelNr(1L)
+								.medBruttoPrÅr(BigDecimal.valueOf(800_000))
+								.medInntektsgrunnlagPrÅr(BigDecimal.valueOf(500_000))
+								.medArbeidsforhold(Arbeidsforhold.builder()
+										.medOrgnr("999999999")
+										.medAktivitet(Aktivitet.ARBEIDSTAKERINNTEKT).build()).build())
+						.build()).build();
+
+		Beregningsgrunnlag.builder()
+				.medBeregningsgrunnlagPeriode(periode)
+				.medGrunnbeløp(BigDecimal.valueOf(100_000));
+
+		var evaluate = new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling().evaluate(periode);
+
+		assertThat(evaluate.result()).isEqualTo(Resultat.NEI);
+	}
+
+	@Test
+	void skal_gi_resultat_NEI_for_inntektsgrunnlag_ikke_satt() {
+		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
+				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
+				.medBeregningsgrunnlagPrStatus(BeregningsgrunnlagPrStatus
+						.builder()
+						.medAktivitetStatus(AktivitetStatus.ATFL)
+						.medArbeidsforhold(BeregningsgrunnlagPrArbeidsforhold.builder()
+								.medAndelNr(1L)
+								.medBruttoPrÅr(BigDecimal.valueOf(800_000))
+								.medArbeidsforhold(Arbeidsforhold.builder()
+										.medOrgnr("999999999")
+										.medAktivitet(Aktivitet.ARBEIDSTAKERINNTEKT).build()).build())
+						.build()).build();
+
+		Beregningsgrunnlag.builder()
+				.medBeregningsgrunnlagPeriode(periode)
+				.medGrunnbeløp(BigDecimal.valueOf(100_000));
+
+		var evaluate = new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling().evaluate(periode);
+
+		assertThat(evaluate.result()).isEqualTo(Resultat.NEI);
+	}
+
+	@Test
+	void skal_gi_resultat_NEI_for_inntektsgrunnlag_lik_grenseverdi() {
+		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
+				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
+				.medBeregningsgrunnlagPrStatus(BeregningsgrunnlagPrStatus
+						.builder()
+						.medAktivitetStatus(AktivitetStatus.ATFL)
+						.medArbeidsforhold(BeregningsgrunnlagPrArbeidsforhold.builder()
+								.medAndelNr(1L)
+								.medBruttoPrÅr(BigDecimal.valueOf(800_000))
+								.medInntektsgrunnlagPrÅr(BigDecimal.valueOf(600_000))
+								.medArbeidsforhold(Arbeidsforhold.builder()
+										.medOrgnr("999999999")
+										.medAktivitet(Aktivitet.ARBEIDSTAKERINNTEKT).build()).build())
+						.build()).build();
+
+		Beregningsgrunnlag.builder()
+				.medBeregningsgrunnlagPeriode(periode)
+				.medGrunnbeløp(BigDecimal.valueOf(100_000));
+
+		var evaluate = new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling().evaluate(periode);
+
+		assertThat(evaluate.result()).isEqualTo(Resultat.NEI);
+	}
+
+}

--- a/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/svp/RegelFinnGrenseverdiMedFordelingTest.java
+++ b/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/svp/RegelFinnGrenseverdiMedFordelingTest.java
@@ -4,9 +4,7 @@ import static no.nav.folketrygdloven.beregningsgrunnlag.util.DateUtil.TIDENES_EN
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +17,6 @@ import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.Beregnings
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPeriode;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrArbeidsforhold;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.BeregningsgrunnlagPrStatus;
-import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.fastsett.TilkommetInntekt;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Arbeidsforhold;
 
 class RegelFinnGrenseverdiMedFordelingTest {
@@ -143,82 +140,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 	}
 
 	@Test
-	void to_arbeidsforhold_under_6G_tilkommet_inntekt_i_det_ene() {
-		//Arrange
-		double beregnetPrÅr = 250_000;
-		double tilkommetPrÅr2 = 100_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 100D, 0D);
-		leggTilArbeidsforhold(periode, AF_2, null, null, 100D, 0D);
-		leggTilTilkommet(periode, AF_2, tilkommetPrÅr2);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(150_000));
-	}
-
-	@Test
-	void to_arbeidsforhold_under_6G_tilkommet_inntekt_i_det_ene_mer_enn_totalt_grunnlag_på_stp() {
-		//Arrange
-		double beregnetPrÅr = 250_000;
-		double tilkommetPrÅr2 = 300_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 100D, 0D);
-		leggTilArbeidsforhold(periode, AF_2, null, null, 100D, 0D);
-		leggTilTilkommet(periode, AF_2, tilkommetPrÅr2);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.ZERO);
-	}
-
-	@Test
-	void to_arbeidsforhold_under_6G_fordelt_og_tilkommet_inntekt_i_det_ene() {
-		//Arrange
-		double beregnetPrÅr = 250_000;
-		double fordeltPrÅr = 150_000;
-
-		double tilkommetPrÅr2 = 100_000;
-		double fordeltPrÅr2 = tilkommetPrÅr2;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, fordeltPrÅr, 100D,0D);
-		leggTilArbeidsforhold(periode, AF_2, null, fordeltPrÅr2, 50D,50D);
-		leggTilTilkommet(periode, AF_2, tilkommetPrÅr2);
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(150_000));
-	}
-
-
-
-	@Test
 	void to_arbeidsforhold_over_6G() {
 		//Arrange
 		double beregnetPrÅr = 350_000;
@@ -240,33 +161,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 
 		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(600_000));
 	}
-
-	@Test
-	void to_arbeidsforhold_over_6G_pluss_et_tilkommet() {
-		//Arrange
-		double beregnetPrÅr = 500_000;
-		double beregnetPrÅr2 = 300_000;
-		double tilkommetPrÅr = 200_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 100D, 0D);
-		leggTilArbeidsforhold(periode, AF_2, beregnetPrÅr2, null, 100D, 0D);
-		leggTilArbeidsforhold(periode, AF_3, null, null, 100D, 0D);
-		leggTilTilkommet(periode, AF_3, tilkommetPrÅr);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(450_000));
-	}
-
 
 	@Test
 	void to_arbeidsforhold_under_6G_søkt_ytelse_for_en() {
@@ -292,32 +186,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(250_000));
 	}
 
-	@Test
-	void to_arbeidsforhold_under_6G_søkt_ytelse_for_en_pluss_et_tilkommet() {
-		//Arrange
-		double beregnetPrÅr = 250_000;
-		double beregnetPrÅr2 = 300_000;
-		double tilkommetPrÅr = 100_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 100D, 0D);
-		leggTilArbeidsforhold(periode, AF_2, beregnetPrÅr2, null, 0D, 100D);
-		leggTilArbeidsforhold(periode, AF_3, null, null, 100D, 100D);
-		leggTilTilkommet(periode, AF_3, tilkommetPrÅr);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(150_000));
-	}
-
 
 	@Test
 	void to_arbeidsforhold_til_sammen_over_6G_søkt_ytelse_for_en() {
@@ -340,57 +208,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 		kjørRegel(periode);
 
 		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(300_000));
-	}
-
-	@Test
-	void to_arbeidsforhold_til_sammen_over_6G_søkt_ytelse_for_en_pluss_et_tilkommet() {
-		//Arrange
-		double beregnetPrÅr = 500_000;
-		double beregnetPrÅr2 = 500_000;
-		double tilkommetPrÅr = 200_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 100D, 0D);
-		leggTilArbeidsforhold(periode, AF_2, beregnetPrÅr2, null, 0D, 100D);
-		leggTilArbeidsforhold(periode, AF_3, null, null, 0D, 100D);
-		leggTilTilkommet(periode, AF_3,tilkommetPrÅr);
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(180_000));
-	}
-
-	@Test
-	void to_arbeidsforhold_til_sammen_over_6G_søkt_ytelse_for_begge_gradert_pluss_et_tilkommet() {
-		//Arrange
-		double beregnetPrÅr = 500_000;
-		double beregnetPrÅr2 = 500_000;
-		double tilkommetPrÅr = 200_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 20D, 80D);
-		leggTilArbeidsforhold(periode, AF_2, beregnetPrÅr2, null, 50D, 50D);
-		leggTilArbeidsforhold(periode, AF_3, null, null, 0D, 100D);
-		leggTilTilkommet(periode, AF_3, tilkommetPrÅr);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi().setScale(2, RoundingMode.HALF_UP)).isEqualByComparingTo(BigDecimal.valueOf(90_000));
 	}
 
 	@Test
@@ -834,82 +651,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(500_000));
 	}
 
-
-	@Test
-	void et_arbeidsforhold_under_6G_tilkommet_frilansinntekt() {
-		//Arrange
-		double beregnetPrÅr = 300_000;
-		double tilkommetFrilansinntekt = 100_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilStatus(periode, AktivitetStatus.FL, null, 100D, 0D);
-		leggTilTilkommet(periode, Arbeidsforhold.frilansArbeidsforhold(), tilkommetFrilansinntekt);
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 100D, 0D);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi().setScale(2, RoundingMode.HALF_UP)).isEqualByComparingTo(BigDecimal.valueOf(200_000));
-	}
-
-	@Test
-	void frilans_og_et_arbeidsforhold_under_6G_søkt_ytelse_for_begge_tilkommet_frilansinntekt() {
-		//Arrange
-		double beregnetPrÅr = 300_000;
-		double beregnetPrÅr2 = 200_000;
-		double tilkommetFrilansinntekt = 100_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilStatus(periode, AktivitetStatus.FL, beregnetPrÅr, 100D, 0D);
-		leggTilTilkommet(periode, Arbeidsforhold.frilansArbeidsforhold(), tilkommetFrilansinntekt);
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr2, null, 100D, 0D);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(400_000));
-	}
-
-	@Test
-	void frilans_og_et_arbeidsforhold_over_6G_søkt_ytelse_for_begge_tilkommet_frilansinntekt() {
-		//Arrange
-		double beregnetPrÅr = 800_000;
-		double beregnetPrÅr2 = 200_000;
-		double tilkommetFrilansinntekt = 200_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilStatus(periode, AktivitetStatus.FL, beregnetPrÅr, 100D, 0D);
-		leggTilTilkommet(periode, Arbeidsforhold.frilansArbeidsforhold(), tilkommetFrilansinntekt);
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr2, null, 100D, 0D);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(480_000));
-	}
-
-
 	@Test
 	void frilans_og_et_arbeidsforhold_over_6G_søkt_ytelse_for_begge() {
 		//Arrange
@@ -1139,30 +880,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 	}
 
 	@Test
-	void næring_under_6G_søkt_delvis_ytelse_tilkommet_inntekt() {
-		//Arrange
-		double beregnetPrÅr = 200_000;
-		double tilkommet = 50_000;
-
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilStatus(periode, AktivitetStatus.SN, beregnetPrÅr, 50D, 50D);
-		leggTilTilkommet(periode, null, tilkommet);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(50_000));
-	}
-
-	@Test
 	void næring_under_6G_ikkje_søkt_ytelse() {
 		//Arrange
 		double beregnetPrÅr = 200_000;
@@ -1225,30 +942,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 		kjørRegel(periode);
 
 		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(600_000));
-	}
-
-	@Test
-	void næring_og_frilans_over_6G_søkt_ytelse_for_begge_tilkommet_næring() {
-		//Arrange
-		double beregnetPrÅr = 500_000;
-		double tilkommet = 100_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilStatus(periode, AktivitetStatus.SN, beregnetPrÅr, 100D, 0D);
-		leggTilTilkommet(periode, null, tilkommet);
-		leggTilStatus(periode, AktivitetStatus.FL, beregnetPrÅr, 100D, 0D);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(540_000));
 	}
 
 	@Test
@@ -1510,79 +1203,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(100_000));
 	}
 
-	@Test
-	void to_arbeidsforhold_under_6G_aktivitetsgrad_høyere_enn_utbetalingsgrad() {
-		//Arrange
-		double beregnetPrÅr = 250_000;
-		double tilkommetPrÅr2 = 100_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 50D, 70D);
-		leggTilArbeidsforhold(periode, AF_2, beregnetPrÅr, null, 50D, 70D);
-		leggTilTilkommet(periode, AF_2, tilkommetPrÅr2);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(50_000));
-	}
-
-	@Test
-	void to_arbeidsforhold_under_6G_aktivitetsgrad_mye_høyere_enn_utbetalingsgrad() {
-		//Arrange
-		double beregnetPrÅr = 250_000;
-		double tilkommetPrÅr2 = 30_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 50D, 90D);
-		leggTilArbeidsforhold(periode, AF_2, beregnetPrÅr, null, 30D, 90D);
-		leggTilTilkommet(periode, AF_2, tilkommetPrÅr2);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi()).isEqualByComparingTo(BigDecimal.valueOf(20_000));
-	}
-
-	@Test
-	void to_arbeidsforhold_under_6G_aktivitetsgrad_lavere_enn_utbetalingsgrad() {
-		//Arrange
-		double beregnetPrÅr = 250_000;
-		double tilkommetPrÅr2 = 30_000;
-
-		BeregningsgrunnlagPeriode periode = BeregningsgrunnlagPeriode.builder()
-				.medPeriode(Periode.of(LocalDate.now(), TIDENES_ENDE))
-				.build();
-
-		Beregningsgrunnlag.builder()
-				.medBeregningsgrunnlagPeriode(periode)
-				.medGrunnbeløp(BigDecimal.valueOf(100_000));
-
-		leggTilArbeidsforhold(periode, AF_1, beregnetPrÅr, null, 90D, 20D);
-		leggTilArbeidsforhold(periode, AF_2, beregnetPrÅr, null, 95D, 10D);
-		leggTilTilkommet(periode, AF_2, tilkommetPrÅr2);
-
-		//Act
-		kjørRegel(periode);
-
-		assertThat(periode.getGrenseverdi().setScale(2, RoundingMode.HALF_UP)).isEqualByComparingTo(BigDecimal.valueOf(395_000));
-	}
-
-
 	private RegelResultat kjørRegel(BeregningsgrunnlagPeriode periode) {
 		return new RegelFinnGrenseverdiMedFordeling(periode).evaluerRegel(periode);
 	}
@@ -1608,25 +1228,6 @@ class RegelFinnGrenseverdiMedFordelingTest {
 		}
 	}
 
-
-	private void leggTilTilkommet(BeregningsgrunnlagPeriode periode,
-	                              Arbeidsforhold arbeidsforhold,
-	                              Double tilkommetPrÅr) {
-		AktivitetStatus status;
-		if (arbeidsforhold == null) {
-			status = AktivitetStatus.SN;
-		} else {
-			status = arbeidsforhold.erFrilanser() ? AktivitetStatus.FL : AktivitetStatus.AT;
-		}
-		lagTilkommet(periode, tilkommetPrÅr, arbeidsforhold, status);
-	}
-
-	private void lagTilkommet(BeregningsgrunnlagPeriode periode, Double tilkommetPrÅr, Arbeidsforhold arbeidsforhold, AktivitetStatus aktivitetStatus) {
-		if (tilkommetPrÅr != null) {
-			var tilkommetInntekt = new TilkommetInntekt(aktivitetStatus, arbeidsforhold, BigDecimal.valueOf(tilkommetPrÅr));
-			BeregningsgrunnlagPeriode.oppdater(periode).leggTilTilkommetInntektsforhold(List.of(tilkommetInntekt));
-		}
-	}
 	private void leggTilStatus(BeregningsgrunnlagPeriode periode,
 	                           AktivitetStatus status,
 	                           Double beregnetPrÅr,
@@ -1672,7 +1273,7 @@ class RegelFinnGrenseverdiMedFordelingTest {
 	                                                                                 Double fordeltPrÅr,
 	                                                                                 double refusjonskrav,
 	                                                                                 double utbetalingsgrad,
-																					 Double aktivitetsgrad,
+	                                                                                 Double aktivitetsgrad,
 	                                                                                 Arbeidsforhold arbeidsforhold) {
 		var bruttoPrÅr = finnBrutto(beregnetPrÅr, fordeltPrÅr);
 		BeregningsgrunnlagPrArbeidsforhold arb = BeregningsgrunnlagPrArbeidsforhold.builder()

--- a/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/svp/RegelFinnGrenseverdiUtenFordelingTest.java
+++ b/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/svp/RegelFinnGrenseverdiUtenFordelingTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.RegelFinnGrenseverdiUtenFordeling;
+import no.nav.folketrygdloven.beregningsgrunnlag.grenseverdi.utenfordeling.RegelFinnGrenseverdiUtenFordeling;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.MidlertidigInaktivType;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.Periode;


### PR DESCRIPTION
* Sjekker inntektsgrunnlag og ikkje brutto pr år for å bestemme om grunnlag er over 6G ved beregning av grenseverdi uten fordeling
* Fjerner tilkommet inntekt logikk fra fra finn grenseverdi uten fordeling siden denne kun kjøres for gamle regler eller for FP/SVP