### PR TITLE
Legger til grunnlag for original kobling med steg-ut tilstand

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/input/StegProsesseringInput.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/input/StegProsesseringInput.java
@@ -41,7 +41,13 @@ public class StegProsesseringInput extends BeregningsgrunnlagInput {
      */
     private BeregningsgrunnlagGrunnlagDto originalGrunnlagFraSteg;
 
-    public StegProsesseringInput(BeregningsgrunnlagInput input, BeregningsgrunnlagTilstand stegTilstand) {
+	/**
+	 * Grunnlag for steg-ut-tilstand fra original behandling som har samme skjæringstidspunkt som grunnlaget til behandling
+	 */
+	private BeregningsgrunnlagGrunnlagDto originalGrunnlagFraStegUt;
+
+
+	public StegProsesseringInput(BeregningsgrunnlagInput input, BeregningsgrunnlagTilstand stegTilstand) {
         super(input);
         this.stegTilstand = stegTilstand;
     }
@@ -61,6 +67,7 @@ public class StegProsesseringInput extends BeregningsgrunnlagInput {
         this.forrigeGrunnlagFraSteg = input.getForrigeGrunnlagFraSteg().orElse(null);
         this.forrigeGrunnlagFraStegUt = input.getForrigeGrunnlagFraStegUt().orElse(null);
         this.originalGrunnlagFraSteg = input.getOriginalGrunnlagFraSteg().orElse(null);
+		this.originalGrunnlagFraStegUt = input.getOriginalGrunnlagFraStegUt().orElse(null);
         this.stegTilstand = input.getStegTilstand();
         this.stegUtTilstand = input.getStegUtTilstandHvisFinnes().orElse(null);
     }
@@ -78,7 +85,11 @@ public class StegProsesseringInput extends BeregningsgrunnlagInput {
         return Optional.ofNullable(originalGrunnlagFraSteg);
     }
 
-    public BeregningsgrunnlagTilstand getStegTilstand() {
+	public Optional<BeregningsgrunnlagGrunnlagDto> getOriginalGrunnlagFraStegUt() {
+		return Optional.ofNullable(originalGrunnlagFraStegUt);
+	}
+
+	public BeregningsgrunnlagTilstand getStegTilstand() {
         return stegTilstand;
     }
 
@@ -112,7 +123,13 @@ public class StegProsesseringInput extends BeregningsgrunnlagInput {
         return newInput;
     }
 
-    public StegProsesseringInput medStegUtTilstand(BeregningsgrunnlagTilstand stegUtTilstand) {
+	public StegProsesseringInput medOriginalGrunnlagFraStegUt(BeregningsgrunnlagGrunnlagDto grunnlag) {
+		var newInput = new StegProsesseringInput(this);
+		newInput.originalGrunnlagFraStegUt = grunnlag;
+		return newInput;
+	}
+
+	public StegProsesseringInput medStegUtTilstand(BeregningsgrunnlagTilstand stegUtTilstand) {
         this.stegUtTilstand = stegUtTilstand;
         return this;
     }


### PR DESCRIPTION
Bakgrunnen for endringen:
Tidligere har vi ikke skilt på forrige grunnlag (som er siste lagrede grunnlag for en gitt tilstand) og originalt grunnlag (som er siste lagrede for en gitt tilstand fra forrige behandling). Dette skillet er nødvendig fordi det i forlengelser ikke skal kopieres verdier fra den gjeldende behandlingen, men kun verdier fra original behandling.

Orginale grunnlag brukes til å kopiering av grunnlag i forlengelser. I en forlengelse er det kun enkelte perioder som skal vurderes, resterende perioder skal kopieres fra original behandling/kobling. Denne kopieringen skjer etter hvert steg. Steg-ut grunnlaget inneholder verdier som har blitt manuelt vurdert av saksbehandler.