### PR TITLE
bugfix: missing empty ctor InntektsgrunnlagInntektDto

### DIFF
--- a/kontrakt/src/main/java/no/nav/folketrygdloven/kalkulus/response/v1/beregningsgrunnlag/gui/inntektsgrunnlag/InntektsgrunnlagInntektDto.java
+++ b/kontrakt/src/main/java/no/nav/folketrygdloven/kalkulus/response/v1/beregningsgrunnlag/gui/inntektsgrunnlag/InntektsgrunnlagInntektDto.java
@@ -32,6 +32,10 @@ public class InntektsgrunnlagInntektDto {
 	@Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{N}]+$", message="'${validatedValue}' matcher ikke tillatt pattern '{regexp}'")
 	private String arbeidsgiverIdent;
 
+	public InntektsgrunnlagInntektDto() {
+		// For jackson
+	}
+
     public InntektsgrunnlagInntektDto(@Valid @NotNull InntektAktivitetType inntektAktivitetType,
                                       @Valid Beløp beløp,
                                       @Valid String arbeidsgiverIdent) {


### PR DESCRIPTION
Denne klassen ble nylig lagt til og manglende Ctor skaper problem i autotest mm.
Har forsøkt med en JsonCreator-annotering - men det lagde problem i fpsak.
Ideelt skal vi mest mulig over til records i kontrakter og vekk fra JsonAutoDetect++ og masse JsonProperty
Men - inntil videre må alle klasser med creatorVisibility = NONE ha en tom Ctor.