### PR TITLE
FIX: Lagrer ned inntektsgradering og regelsporing ved bekreftelse av aksjonspunkt

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/regelmodelltilvl/fastsett/MapFastsattBeregningsgrunnlagFraRegelTilVL.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/regelmodelltilvl/fastsett/MapFastsattBeregningsgrunnlagFraRegelTilVL.java
@@ -41,11 +41,20 @@ public class MapFastsattBeregningsgrunnlagFraRegelTilVL {
                 }
             }
             fastsettAgreggerteVerdier(eksisterendePeriode, eksisterendeVLGrunnlag);
+            validerUendretVerdiDersomAlleredeSatt(eksisterendePeriode.getTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt(), resultatBGPeriode.getTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt(), "totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt");
             BeregningsgrunnlagPeriodeDto.oppdater(eksisterendePeriode)
                     .medInntektsgraderingsprosentBrutto(resultatBGPeriode.getInntektsgraderingFraBruttoBeregningsgrunnlag())
                     .medTotalUtbetalingsgradFraUttak(resultatBGPeriode.getTotalUtbetalingsgradFraUttak())
                     .medTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt(resultatBGPeriode.getTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt())
                     .medReduksjonsfaktorInaktivTypeA(resultatBGPeriode.getReduksjonsfaktorInaktivTypeA());
+        }
+    }
+
+    private void validerUendretVerdiDersomAlleredeSatt(BigDecimal eksisterende,
+                                                       BigDecimal ny,
+                                                       String navn) {
+        if (eksisterende != null && eksisterende.compareTo(ny) > 0) {
+            throw new IllegalArgumentException("Verdi for " + navn  + " skal ikke endres");
         }
     }
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/avklaringsbehov/VurderTilkommetInntektTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/avklaringsbehov/VurderTilkommetInntektTjenesteTest.java
@@ -6,6 +6,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagAktivitetStatusDto;
+
 import org.junit.jupiter.api.Test;
 
 import no.nav.folketrygdloven.kalkulator.KoblingReferanseMock;
@@ -80,9 +82,9 @@ class VurderTilkommetInntektTjenesteTest {
         var input = lagInput(periode, yrkesaktiviteter, utbetalingsgrader, andeler, vurderteInntektsforhold);
 
         // Act
-        var nyttGr = VurderTilkommetInntektTjeneste.løsAvklaringsbehov(dto, new HåndterBeregningsgrunnlagInput(input, BeregningsgrunnlagTilstand.FASTSATT_INN));
+        var nyttGr = løsAvklaringsbehov(dto, input);
 
-        var tilkomneInntekter = nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().get(0)
+        var tilkomneInntekter = nyttGr.getBeregningsgrunnlagPerioder().get(0)
                 .getTilkomneInntekter();
 
         // Assert
@@ -128,19 +130,19 @@ class VurderTilkommetInntektTjenesteTest {
         var input = lagInput(periode, yrkesaktiviteter, utbetalingsgrader, andeler, vurderteInntektsforhold);
 
         // Act
-        var nyttGr = VurderTilkommetInntektTjeneste.løsAvklaringsbehov(dto, new HåndterBeregningsgrunnlagInput(input, BeregningsgrunnlagTilstand.FASTSATT_INN));
+        var nyttGr = løsAvklaringsbehov(dto, input);
 
 
         // Assert
-        assertThat(nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().size()).isEqualTo(2);
-        var tilkomneInntekter1 = nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().get(0)
+        assertThat(nyttGr.getBeregningsgrunnlagPerioder().size()).isEqualTo(2);
+        var tilkomneInntekter1 = nyttGr.getBeregningsgrunnlagPerioder().get(0)
                 .getTilkomneInntekter();
         assertThat(tilkomneInntekter1.size()).isEqualTo(1);
         assertThat(tilkomneInntekter1.get(0).getArbeidsgiver().get()).isEqualTo(arbeidsgiver2);
         assertThat(tilkomneInntekter1.get(0).getAktivitetStatus()).isEqualTo(AktivitetStatus.ARBEIDSTAKER);
         assertThat(tilkomneInntekter1.get(0).getBruttoInntektPrÅr().compareTo(Beløp.fra(100_000))).isEqualTo(0);
 
-        var periodeLagtTil = nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().get(1);
+        var periodeLagtTil = nyttGr.getBeregningsgrunnlagPerioder().get(1);
         var tilkomneInntekter2 = periodeLagtTil
                 .getTilkomneInntekter();
         assertThat(periodeLagtTil.getPeriodeÅrsaker().contains(PeriodeÅrsak.TILKOMMET_INNTEKT_MANUELT)).isTrue();
@@ -185,19 +187,19 @@ class VurderTilkommetInntektTjenesteTest {
         var input = lagInput(periode, yrkesaktiviteter, utbetalingsgrader, andeler, vurderteInntektsforhold);
 
         // Act
-        var nyttGr = VurderTilkommetInntektTjeneste.løsAvklaringsbehov(dto, new HåndterBeregningsgrunnlagInput(input, BeregningsgrunnlagTilstand.FASTSATT_INN));
+        var nyttGr = løsAvklaringsbehov(dto, input);
 
 
         // Assert
-        assertThat(nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().size()).isEqualTo(2);
-        var tilkomneInntekter1 = nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().get(0)
+        assertThat(nyttGr.getBeregningsgrunnlagPerioder().size()).isEqualTo(2);
+        var tilkomneInntekter1 = nyttGr.getBeregningsgrunnlagPerioder().get(0)
                 .getTilkomneInntekter();
         assertThat(tilkomneInntekter1.size()).isEqualTo(1);
         assertThat(tilkomneInntekter1.get(0).getArbeidsgiver().get()).isEqualTo(arbeidsgiver2);
         assertThat(tilkomneInntekter1.get(0).getAktivitetStatus()).isEqualTo(AktivitetStatus.ARBEIDSTAKER);
         assertThat(tilkomneInntekter1.get(0).getBruttoInntektPrÅr().compareTo(Beløp.fra(100_000))).isEqualTo(0);
 
-        var periodeLagtTil = nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().get(1);
+        var periodeLagtTil = nyttGr.getBeregningsgrunnlagPerioder().get(1);
         var tilkomneInntekter2 = periodeLagtTil
                 .getTilkomneInntekter();
         assertThat(tilkomneInntekter2.size()).isEqualTo(1);
@@ -237,9 +239,9 @@ class VurderTilkommetInntektTjenesteTest {
         var input = lagInput(periode, yrkesaktiviteter, utbetalingsgrader, andeler, vurderteInntektsforhold);
 
         // Act
-        var nyttGr = VurderTilkommetInntektTjeneste.løsAvklaringsbehov(dto, new HåndterBeregningsgrunnlagInput(input, BeregningsgrunnlagTilstand.FASTSATT_INN));
+        var nyttGr = løsAvklaringsbehov(dto, input);
 
-        var tilkomneInntekter = nyttGr.getBeregningsgrunnlagHvisFinnes().get().getBeregningsgrunnlagPerioder().get(0)
+        var tilkomneInntekter = nyttGr.getBeregningsgrunnlagPerioder().get(0)
                 .getTilkomneInntekter();
 
         // Assert
@@ -249,6 +251,12 @@ class VurderTilkommetInntektTjenesteTest {
         assertThat(tilkomneInntekter.get(0).getBruttoInntektPrÅr().compareTo(Beløp.fra(100_000))).isEqualTo(0);
 
 
+    }
+
+    private static BeregningsgrunnlagDto løsAvklaringsbehov(VurderTilkommetInntektHåndteringDto dto,
+                                                                                                     BeregningsgrunnlagInput input) {
+        return VurderTilkommetInntektTjeneste.løsAvklaringsbehov(dto,
+            new HåndterBeregningsgrunnlagInput(input, BeregningsgrunnlagTilstand.FASTSATT_INN)).grunnlag().getBeregningsgrunnlag();
     }
 
     private BeregningsgrunnlagInput lagInput(Intervall periode, List<YrkesaktivitetDto> yrkesaktiviteter, List<UtbetalingsgradPrAktivitetDto> utbetalingsgrader, List<BeregningsgrunnlagPrStatusOgAndelDto> andeler, List<NyttInntektsforholdDto> vurderteInntektsforhold) {
@@ -290,6 +298,7 @@ class VurderTilkommetInntektTjenesteTest {
                 .forEach(periodeBuilder::leggTilTilkommetInntekt);
         return BeregningsgrunnlagGrunnlagDtoBuilder.nytt()
                 .medBeregningsgrunnlag(BeregningsgrunnlagDto.builder()
+                    .leggTilAktivitetStatus(BeregningsgrunnlagAktivitetStatusDto.builder().medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER))
                         .leggTilBeregningsgrunnlagPeriode(periodeBuilder)
                         .medSkjæringstidspunkt(fom)
                         .medGrunnbeløp(Beløp.fra(100_000))

--- a/kodeverk/src/main/java/no/nav/folketrygdloven/kalkulus/kodeverk/BeregningsgrunnlagPeriodeRegelType.java
+++ b/kodeverk/src/main/java/no/nav/folketrygdloven/kalkulus/kodeverk/BeregningsgrunnlagPeriodeRegelType.java
@@ -4,6 +4,8 @@ import static no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstan
 import static no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand.FORESLÅTT;
 import static no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand.FORESLÅTT_DEL_2;
 import static no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand.OPPDATERT_MED_REFUSJON_OG_GRADERING;
+import static no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand.VURDERT_TILKOMMET_INNTEKT;
+import static no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand.VURDERT_TILKOMMET_INNTEKT_UT;
 import static no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand.VURDERT_VILKÅR;
 
 
@@ -11,6 +13,7 @@ public enum BeregningsgrunnlagPeriodeRegelType implements Kodeverdi, DatabaseKod
     FORESLÅ(FORESLÅTT), // Foreslå beregningsgrunnlag
     FORESLÅ_2(FORESLÅTT_DEL_2), // Foreslå beregningsgrunnlag del 2
     VILKÅR_VURDERING(VURDERT_VILKÅR), // Vurder beregningsvilkår
+    FINN_GRENSEVERDI_FOR_TILKOMMET_INNTEKT(VURDERT_TILKOMMET_INNTEKT_UT), // Finne grenseverdi og inntektsgradering for tilkommet inntekt
     FORDEL(OPPDATERT_MED_REFUSJON_OG_GRADERING), // Fordel beregningsgrunnlag
     FASTSETT(FASTSATT), // Fastsett/fullføre beregningsgrunnlag
     FINN_GRENSEVERDI(FASTSATT), // Finne grenseverdi til kjøring av fastsett beregningsgrunnlag for SVP


### PR DESCRIPTION
For bedre sporing av hvilke verdier uttak benytter seg av ved gradering mot inntekt lagres disse verdiene ned etter at saksbehandler bekrefter aksjonspunkt. Restendepunkt for inntektgradering kan så bruke verdiene som er lagret ned i staden for å utlede det direkte i restkallet. Mapping i fastsett-steget utvides med validering der vi sjekker at verdien for inntektsgradering ikkje har endret seg sidan uttakssteget.