### PR TITLE
TFP-6361 forutsett vedtaksdagsats for nye tilfelle av AAP / DAG

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/MapInntektsgrunnlagVLTilRegelFRISINN.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/MapInntektsgrunnlagVLTilRegelFRISINN.java
@@ -152,9 +152,7 @@ public class MapInntektsgrunnlagVLTilRegelFRISINN implements MapInntektsgrunnlag
     }
 
     private Beløp finnBeløp(YtelseAnvistDto anvist, Optional<Beløp> vedtaksDagsats) {
-        var beløpFraYtelseAnvist = anvist.getBeløp()
-                .orElse(anvist.getDagsats().orElse(Beløp.ZERO));
-        return vedtaksDagsats.orElse(beløpFraYtelseAnvist);
+        return vedtaksDagsats.or(anvist::getDagsats).orElse(Beløp.ZERO);
     }
 
     private List<Periodeinntekt> lagInntekterSN(InntektFilterDto filter) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/MapInntektsgrunnlagVLTilRegelFelles.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/MapInntektsgrunnlagVLTilRegelFelles.java
@@ -203,8 +203,8 @@ public class MapInntektsgrunnlagVLTilRegelFelles implements MapInntektsgrunnlagV
 				.map(verdi -> nyesteVedtakForDagsats.harKildeKelvin() ? verdi.divide(MeldekortUtils.MAX_UTBETALING_PROSENT_AAP_KELVIN, 10, RoundingMode.HALF_UP) : verdi.divide(MeldekortUtils.MAX_UTBETALING_PROSENT_AAP_DAG_ARENA, 10, RoundingMode.HALF_UP))
 				.orElse(BigDecimal.ONE);
 
-		dagsats = nyesteVedtakForDagsats.getVedtaksDagsats().map(Beløp::verdi)
-				.orElse(sisteUtbetalingFørStp.flatMap(YtelseAnvistDto::getBeløp).map(Beløp::verdi).orElse(BigDecimal.ZERO));
+		dagsats = nyesteVedtakForDagsats.getVedtaksDagsats().map(Beløp::verdi).orElseThrow();
+
 		return Periodeinntekt.builder()
 				.medInntektskildeOgPeriodeType(Inntektskilde.TILSTØTENDE_YTELSE_DP_AAP)
 				.medInntekt(dagsats)

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YtelseAnvistDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YtelseAnvistDto.java
@@ -27,7 +27,6 @@ public class YtelseAnvistDto {
         this.beløp = ytelseAnvist.getBeløp().orElse(null);
         this.dagsats = ytelseAnvist.getDagsats().orElse(null);
         this.utbetalingsgradProsent = ytelseAnvist.getUtbetalingsgradProsent().orElse(null);
-        this.utbetalingsgradProsent = ytelseAnvist.getUtbetalingsgradProsent().orElse(null);
 
     }
 


### PR DESCRIPTION
Har undersøkt historikk og alle innhentinger fra Arena for AAP og Dagpenger etter november 2019 har med vedtaksdagsats. Det er noen få unntak fra tidlig 2020 som antagelig er kopiert fra 2019 (berørte behandlinger).

Legger derfor opp til å forutsette vedtaksdagsats her i regelmappingen (nye revurderinger vil hente nye registerdata), men beholde fallback til anvist dagsats i FinnInntektFraYtelse - som brukes for visning - også av tilfelle fra før vedtaksdagsats ble innført

Kan gjøre fallback til ZERO dersom denne virker dramatisk (tenk testcases) ...