### PR TITLE
TSFF-1923: Tar ikke hensyn til refusjonskrav for arbeidsforhold der det ikke finnes ansattperioder etter startdato

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/MapRefusjonPerioderFraVLTilRegelUtbgrad.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/MapRefusjonPerioderFraVLTilRegelUtbgrad.java
@@ -64,6 +64,10 @@ public class MapRefusjonPerioderFraVLTilRegelUtbgrad
             // Refusjon opphører før det utledede startpunktet, blir aldri refusjon
             return Collections.emptyList();
         }
+        if (harIngenAnsattperioderEtterStartDato(startdatoEtterPermisjon, ansattperioder)) {
+            // Dersom bruker ikke er ansatt en eneste dag etter stardato for ytelsen tar vi ikke hensyn til eventuelle refusjonskrav fra arbeidsgiver
+            return Collections.emptyList();
+        }
         if (ytelsespesifiktGrunnlag instanceof UtbetalingsgradGrunnlag) {
             var utbetalingTidslinje = finnUtbetalingTidslinje((UtbetalingsgradGrunnlag) ytelsespesifiktGrunnlag, im);
             return utbetalingTidslinje
@@ -73,6 +77,10 @@ public class MapRefusjonPerioderFraVLTilRegelUtbgrad
                     .collect(Collectors.toList());
         }
         throw new IllegalStateException("Forventet utbetalingsgrader men fant ikke UtbetalingsgradGrunnlag.");
+    }
+
+    private static boolean harIngenAnsattperioderEtterStartDato(LocalDate startdatoEtterPermisjon, List<AktivitetsAvtaleDto> ansattperioder) {
+        return !ansattperioder.isEmpty() && ansattperioder.stream().allMatch(it -> it.getPeriode().getTomDato().isBefore(startdatoEtterPermisjon));
     }
 
     private LocalDateTimeline<Boolean> finnUtbetalingTidslinje(UtbetalingsgradGrunnlag ytelsespesifiktGrunnlag, InntektsmeldingDto im) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/MapRefusjonPerioderFraVLTilRegelUtbgradTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/MapRefusjonPerioderFraVLTilRegelUtbgradTest.java
@@ -219,7 +219,32 @@ class MapRefusjonPerioderFraVLTilRegelUtbgradTest {
         Assertions.assertThat(opphør.getPeriode().getFom()).isEqualTo(LocalDate.of(2020, 1, 19).plusDays(1));
     }
 
-	@Test
+    @Test
+    void skal_ikke_returnere_refusjonsperiode_dersom_ikke_ansatt_etter_start() {
+        var stp = LocalDate.now();
+        var arbeidsgiver = Arbeidsgiver.virksomhet("123456789");
+        var utbetalingsperiode = Intervall.fraOgMedTilOgMed(stp.plusDays(20), stp.plusDays(25));
+        var gradForTilkommetArbeid = new UtbetalingsgradPrAktivitetDto(
+            new AktivitetDto(arbeidsgiver, InternArbeidsforholdRefDto.nullRef(), UttakArbeidType.ORDINÆRT_ARBEID),
+            List.of(new PeriodeMedUtbetalingsgradDto(utbetalingsperiode, new Utbetalingsgrad(BigDecimal.valueOf(100)),
+                new Aktivitetsgrad(BigDecimal.valueOf(0)))));
+        var ytelsespesifiktGrunnlag = new PleiepengerSyktBarnGrunnlag(List.of(gradForTilkommetArbeid));
+        var inntektsmelding = lagInntektsmelding(stp, arbeidsgiver);
+        var ansettelsesperiode = Intervall.fraOgMedTilOgMed(stp.minusYears(10), stp.minusDays(1));
+        var aktivitetsAvtaleDtoBuilder = AktivitetsAvtaleDtoBuilder.ny().medPeriode(ansettelsesperiode).medErAnsettelsesPeriode(true);
+        var permisjonsperiode = Intervall.fraOgMedTilOgMed(stp, stp.plusDays(15));
+        var relaterteYrkesaktiviteter = Set.of(lagYrkesaktivitet(arbeidsgiver, aktivitetsAvtaleDtoBuilder, permisjonsperiode));
+
+        var avtaler = relaterteYrkesaktiviteter.iterator().next().getAlleAnsettelsesperioder().stream().toList();
+        var perioder = mapper.finnGyldigeRefusjonPerioder(stp, ytelsespesifiktGrunnlag, inntektsmelding, avtaler, relaterteYrkesaktiviteter);
+
+        assertThat(perioder.isEmpty()).isTrue();
+    }
+
+
+
+
+    @Test
 	void skal_ikke_returnere_periode_for_fravær_fra_arbeidsgiver_men_ingen_uttak() {
 		var stp = LocalDate.now();
 		var arbeidsgiver = Arbeidsgiver.virksomhet("123456789");


### PR DESCRIPTION
Dersom eit arbeidsforhold inngår i beregningsgrunnlaget fordi arbeidsforholdet var aktivt dagen før skjæringstidspunktet, men opphører dagen før skjæringstidspunktet, skal ikkje refusjonskrav frå dette arbeidsforholdet tas hensyn til.