### PR TITLE
TSFF-1908: Legg til OLP i mapYtelsesSpesifiktGrunnlag

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
@@ -76,7 +76,7 @@ public class MapFullføreBeregningsgrunnlagFraVLTilRegel {
 
     private YtelsesSpesifiktGrunnlag mapYtelsesSpesifiktGrunnlag(BeregningsgrunnlagInput input) {
         return switch (input.getFagsakYtelseType()) {
-            case PLEIEPENGER_SYKT_BARN, PLEIEPENGER_NÆRSTÅENDE -> new PleiepengerGrunnlagMapperFastsett().map(input);
+            case PLEIEPENGER_SYKT_BARN, PLEIEPENGER_NÆRSTÅENDE, OPPLÆRINGSPENGER -> new PleiepengerGrunnlagMapperFastsett().map(input);
             case FRISINN -> new FrisinnGrunnlagMapperFastsett().map(input);
             default -> null;
         };


### PR DESCRIPTION
Dersom denne ikke mappes til riktig ytelsespesifikt gunnlag feiler regelevaluering av SkalFinneGrenseverdiUtenFordeling og tilkommende inntekt reduserer ikke beløp